### PR TITLE
New data entry page structure 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import "package:lighthouse/pages/amongview_individual.dart";
 import "package:lighthouse/pages/home_data_viewer.dart";
 import "package:lighthouse/pages/home_scouter.dart";
 import "package:lighthouse/constants.dart";
+import "package:lighthouse/pages/rebuilt/atlas.dart";
 import "package:lighthouse/pages/saved_data.dart";
 import "package:lighthouse/pages/settings.dart";
 import "package:lighthouse/pages/sync.dart";
@@ -43,6 +44,7 @@ class MainWidget extends StatelessWidget {
       routes: {
         // TODO: figure out how to transition to page-based data entry layouts
         "/home-scouter": (context) => ScouterHomePage(),
+        "/atlas": (context) => Atlas(), 
         "/settings": (context) => SettingsPage(),
         "/saved_data": (context) => SavedData(),
         "/home-data-viewer": (context) => DataViewerHome(),

--- a/lib/pages/data_entry_page.dart
+++ b/lib/pages/data_entry_page.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:lighthouse/constants.dart';
+import 'package:lighthouse/data_entry.dart';
+import 'package:lighthouse/filemgr.dart';
+
+class DataEntryPage extends StatefulWidget {
+  const DataEntryPage({super.key, required this.pages, required this.name});
+  // TODO: Decide if this should be Container or Widget
+  final Map<String, Container> pages;
+  final String name;
+
+  @override
+  State<DataEntryPage> createState() => DataEntryPageState();
+}
+
+class DataEntryPageState extends State<DataEntryPage> {
+  Map<String, Container> get _pages => widget.pages;
+  String get _name => widget.name;
+  int currentPage = 0;
+  static late double deviceWidth;
+  static late double deviceHeight;
+  late PageController controller;
+  double startDrag = 0.0;
+  bool hasEventKeyWarningShown = false;
+
+  @override
+  void initState() {
+    super.initState();
+    DataEntry.exportData.clear();
+    controller = PageController(initialPage: 0);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    deviceWidth = MediaQuery.sizeOf(context).width;
+    deviceHeight = MediaQuery.sizeOf(context).height;
+  }
+
+  
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+    DataEntry.activeConfig =
+        (ModalRoute.of(context)?.settings.arguments as String?)!;
+
+    if (!hasEventKeyWarningShown &&
+        defaultConfig["eventKey"] == configData["eventKey"]) {
+      hasEventKeyWarningShown = true;
+      Future.delayed(Duration.zero, () {
+        showDialog(
+            context: context,
+            builder: (context) {
+              return Dialog(
+                child: Container(
+                    padding: EdgeInsets.all(Constants.borderRadius),
+                    child: Text(
+                        "You are using the default event key! Go to Settings to change your event key.")),
+              );
+            });
+      });
+    }
+
+    return PopScope(
+      canPop: false,
+      child: GestureDetector(
+        // Allows keyboard to be closed when anywhere else is clicked on screen
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: Scaffold(
+            // Prevents background image from being resized when keyboard opens
+            resizeToAvoidBottomInset: false,
+            appBar: AppBar(
+              backgroundColor:
+                  themeColorPalettes[configData["theme"] ?? "Dark"]![0],
+              title: FittedBox(
+                child: AutoSizeText(
+                  "${DataEntry.activeConfig} - ${createNavBar(layoutJSON["pages"])[currentPage].label}",
+                  style: TextStyle(
+                      fontFamily: "Comfortaa",
+                      fontWeight: FontWeight.w900,
+                      color: Constants.pastelWhite),
+                  minFontSize: 4,
+                ),
+              ),
+              centerTitle: true,
+              leading: IconButton(
+                  onPressed: () {
+                    showReturnDialog(context);
+                  },
+                  icon: Icon(Icons.home, color: Constants.pastelWhite)),
+              actions: [
+                if (configData["debugMode"] == "true")
+                  IconButton(
+                    icon: Icon(Icons.javascript, color: Constants.pastelWhite),
+                    onPressed: () {
+                      showDialog(
+                          context: context,
+                          builder: (BuildContext) {
+                            return Dialog(
+                              child: Text(jsonEncode(configData)),
+                            );
+                          });
+                    },
+                  ),
+                IconButton(
+                    onPressed: () {
+                      saveJson(context);
+                    },
+                    icon: Icon(
+                      Icons.save,
+                      color: Constants.pastelWhite,
+                    ))
+              ],
+            ),
+            bottomNavigationBar: buildBottomNavBar(_pages),
+            body: Container(
+              height: screenHeight,
+              width: screenWidth,
+              decoration: BoxDecoration(
+                  image: DecorationImage(
+                      image: AssetImage(backgrounds[configData["theme"]] ??
+                          "assets/images/background-hires-dark.png"),
+                      fit: BoxFit.fill)),
+              child: NotificationListener<OverscrollNotification>(
+                onNotification: (notification) {
+                  if (notification.metrics.axis == Axis.vertical) {
+                    return true;
+                  }
+                  debugPrint(notification.overscroll.toString());
+                  if (notification.overscroll < -25) {
+                    showReturnDialog(context);
+                  }
+                  if (notification.overscroll > 25) {
+                    saveJson(context);
+                  }
+                  return true;
+                },
+                child: ScrollConfiguration(
+                  behavior: ScrollBehavior().copyWith(overscroll: false),
+                  child: PageView(
+                    controller: controller,
+                    scrollDirection: Axis.horizontal,
+                    // Forces overscroll to trigger OverscrollNotification instead
+                    // of allowing overscroll itself
+                    // Forces overscroll to trigger OverscrollNotification instead
+                    // of allowing overscroll itself
+                    physics: ClampingScrollPhysics(),
+                    children: _pages.values.toList(),
+                    onPageChanged: (index) {
+                      setState(() {
+                        currentPage = index;
+                      });
+                    },
+                  ),
+                ),
+              ),
+            )),
+      ),
+    );
+  }
+}

--- a/lib/pages/data_entry_page.dart
+++ b/lib/pages/data_entry_page.dart
@@ -2,14 +2,16 @@ import 'dart:convert';
 
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:lighthouse/constants.dart';
 import 'package:lighthouse/data_entry.dart';
 import 'package:lighthouse/filemgr.dart';
+import 'package:lighthouse/pages/data_entry_sub_page.dart';
 
 class DataEntryPage extends StatefulWidget {
   const DataEntryPage({super.key, required this.pages, required this.name});
   // TODO: Decide if this should be Container or Widget
-  final Map<String, Container> pages;
+  final Map<String, DataEntrySubPage> pages;
   final String name;
 
   @override
@@ -17,7 +19,7 @@ class DataEntryPage extends StatefulWidget {
 }
 
 class DataEntryPageState extends State<DataEntryPage> {
-  Map<String, Container> get _pages => widget.pages;
+  Map<String, DataEntrySubPage> get _pages => widget.pages;
   String get _name => widget.name;
   int currentPage = 0;
   static late double deviceWidth;
@@ -40,8 +42,6 @@ class DataEntryPageState extends State<DataEntryPage> {
     deviceWidth = MediaQuery.sizeOf(context).width;
     deviceHeight = MediaQuery.sizeOf(context).height;
   }
-
-  
 
   @override
   void dispose() {
@@ -86,7 +86,7 @@ class DataEntryPageState extends State<DataEntryPage> {
                   themeColorPalettes[configData["theme"] ?? "Dark"]![0],
               title: FittedBox(
                 child: AutoSizeText(
-                  "${DataEntry.activeConfig} - ${createNavBar(layoutJSON["pages"])[currentPage].label}",
+                  "$_name - ${createNavBar(_pages)[currentPage].label}",
                   style: TextStyle(
                       fontFamily: "Comfortaa",
                       fontWeight: FontWeight.w900,
@@ -168,6 +168,52 @@ class DataEntryPageState extends State<DataEntryPage> {
               ),
             )),
       ),
+    );
+  }
+
+  ///returns a list of the BottomNavigationBarItems that each of the pages gives it.
+  List<BottomNavigationBarItem> createNavBar(Map<String, DataEntrySubPage> pages) {
+    List<BottomNavigationBarItem> items = List<BottomNavigationBarItem>.empty(growable: true);
+    for (var entry in pages.entries) {
+      String title = entry.key;
+      Icon icon = Icon(entry.value.icon);
+      items.add(BottomNavigationBarItem(icon: icon, label: title));
+    }
+    return items;
+  }
+
+  Widget? buildBottomNavBar(Map<String, DataEntrySubPage> pages) {
+    if (pages.length < 2) {
+      return null;
+    }
+    return Theme(
+      data: ThemeData(splashFactory: NoSplash.splashFactory),
+      child: BottomNavigationBar(
+          onTap: (index) {
+            setState(() {
+              if (currentPage != index) {
+                HapticFeedback.mediumImpact();
+              }
+              currentPage = index;
+
+              controller.animateToPage(index,
+                  duration: Duration(milliseconds: 300),
+                  curve: Curves.decelerate);
+            });
+          },
+          unselectedIconTheme:
+              IconThemeData(color: Constants.pastelWhite, size: 25),
+          unselectedItemColor: Constants.pastelWhite,
+          selectedIconTheme:
+              IconThemeData(color: Constants.pastelWhite, size: 35),
+          selectedItemColor: Constants.pastelWhite,
+          currentIndex: currentPage,
+          showUnselectedLabels: false,
+          showSelectedLabels: false,
+          type: BottomNavigationBarType.fixed,
+          backgroundColor:
+              themeColorPalettes[configData["theme"] ?? "Dark"]![1],
+          items: createNavBar(pages)),
     );
   }
 }

--- a/lib/pages/data_entry_sub_page.dart
+++ b/lib/pages/data_entry_sub_page.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class DataEntrySubPage extends StatefulWidget {
+  const DataEntrySubPage(
+      {super.key, required this.content, required this.icon});
+  // TODO: Decide if this should be Container or Widget
+  final Container content;
+  final IconData icon;
+
+  @override
+  State<DataEntrySubPage> createState() => DataEntrySubPageState();
+}
+
+class DataEntrySubPageState extends State<DataEntrySubPage> {
+  Container get _content => widget.content;
+  @override
+  Widget build(Object context) {
+    return _content;
+  }
+}

--- a/lib/pages/home_scouter.dart
+++ b/lib/pages/home_scouter.dart
@@ -27,15 +27,10 @@ class _ScouterHomePageState extends State<ScouterHomePage> {
 
   // This method generates a list of Launcher widgets based on layouts.
   List<Launcher> getLaunchers() {
-    final enabledLayouts = layoutMap.keys;
-    final enabledLaunchers = enabledLayouts.map((layout) {
-      return Launcher(
-        icon: iconMap[layout] ?? Icons.data_object,
-        title: layout,
-        color: colorMap[layout] ?? Colors.black,
-      );
-    }).toList();
+    final enabledLaunchers = List<Launcher>.empty(growable: true);
     // Adding extra launchers for viewing saved data and syncing to the server.
+    enabledLaunchers.add(Launcher(
+        icon: Icons.public, title: "Atlas", route: "/atlas", color: Constants.pastelRed));
     enabledLaunchers.add(Launcher(
       icon: Icons.folder,
       title: "View Saved Data",

--- a/lib/pages/rebuilt/atlas.dart
+++ b/lib/pages/rebuilt/atlas.dart
@@ -1,4 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:lighthouse/constants.dart';
+import 'package:lighthouse/custom_icons.dart';
+import 'package:lighthouse/pages/data_entry_page.dart';
+import 'package:lighthouse/pages/data_entry_sub_page.dart';
+import 'package:lighthouse/widgets/game_agnostic/match_info.dart';
+import 'package:lighthouse/widgets/game_agnostic/placeholder.dart';
 
 class Atlas extends StatefulWidget {
   const Atlas({super.key});
@@ -10,7 +16,20 @@ class Atlas extends StatefulWidget {
 class AtlasState extends State<Atlas> {
   @override
   Widget build(BuildContext context) {
-    // TODO: implement build
-    throw UnimplementedError();
+    return DataEntryPage(
+      name: "Atlas", 
+      pages: {
+        "Setup": DataEntrySubPage(icon: CustomIcons.wrench, content: Container(
+          child: Column(
+            children: [
+              MatchInfo()
+            ],
+          )
+        )), 
+        "Auto": DataEntrySubPage(icon: CustomIcons.autonomous,content: Container(
+          child: NRGPlaceholder(title: "placeholder", jsonKey: "none", height: 20, width: 20)
+        ),)
+      }
+    );
   }
 }

--- a/lib/pages/rebuilt/atlas.dart
+++ b/lib/pages/rebuilt/atlas.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class Atlas extends StatefulWidget {
+  const Atlas({super.key});
+
+  @override
+  State<Atlas> createState() => AtlasState();
+}
+
+class AtlasState extends State<Atlas> {
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement build
+    throw UnimplementedError();
+  }
+}

--- a/lib/splash_texts.dart
+++ b/lib/splash_texts.dart
@@ -29,6 +29,8 @@ final List<String> splashTexts = [
   "It's not a bug, it's a feature!",
   "Give us a better name",
   "W IT",
+  "Don't fall!", 
+  "build a turret", 
   "Well... As long as it works...",
   "Dart? Well, it builds quite slow in my opinion...",
   "Programmer? I'm glad you support proper English",


### PR DESCRIPTION
- think of "DataEntryPage" as a better Scaffold
- use DataEntrySubPage to fill out the contents of the DataEntryPage
- TODO: work out DataEntry export data stuff
- Each data entry page (atlas, pit, etc) is its own stateful widget... the build function should contain one and only on DataEntryPage, which then contains sub pages, inside of which you define the contents of the sub pages